### PR TITLE
stop using deprecated $dsl->request

### DIFF
--- a/lib/Dancer2/Plugin/Ajax.pm
+++ b/lib/Dancer2/Plugin/Ajax.pm
@@ -25,7 +25,7 @@ register 'ajax' => sub {
     my $ajax_route = sub {
 
         # # must be an XMLHttpRequest
-        if ( not $dsl->request->is_ajax ) {
+        if ( not $dsl->app->request->is_ajax ) {
             $dsl->pass and return 0;
         }
 


### PR DESCRIPTION
Plugin works fine with Plugin2 without this change but emits warnings.
