### PR TITLE
Restore layout after route exception happened

### DIFF
--- a/lib/Dancer2/Plugin/Ajax.pm
+++ b/lib/Dancer2/Plugin/Ajax.pm
@@ -43,8 +43,14 @@ sub ajax {
         # disable layout
         my $layout = $plugin->app->config->{'layout'};
         $plugin->app->config->{'layout'} = undef;
-        my $response = $code->();
+        my $response = eval { $code->(); };
+        my $error = $@;
+        # Restore layout first
         $plugin->app->config->{'layout'} = $layout;
+        # Then give way to the route exception
+        if( $error ) {
+            die($error);
+        }
         return $response;
     };
 


### PR DESCRIPTION
This is a short fix for when a route exception happens in an 'ajax' route to restore at least the saved layout before giving way to the raised exception.